### PR TITLE
Fetched URI matched the mortyurl.

### DIFF
--- a/morty.go
+++ b/morty.go
@@ -163,18 +163,11 @@ func (p *Proxy) RequestHandler(ctx *fasthttp.RequestCtx) {
 	defer fasthttp.ReleaseRequest(req)
 	req.SetConnectionClose()
 
-	reqQuery := parsedURI.Query()
-	ctx.QueryArgs().VisitAll(func(key, value []byte) {
-		reqQuery.Add(string(key), string(value))
-	})
+	requestURIStr := string(requestURI)
 
-	parsedURI.RawQuery = reqQuery.Encode()
+	log.Println("getting", requestURIStr)
 
-	uriStr := parsedURI.String()
-
-	log.Println("getting", uriStr)
-
-	req.SetRequestURI(uriStr)
+	req.SetRequestURI(requestURIStr)
 	req.Header.SetUserAgentBytes([]byte("Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36"))
 
 	resp := fasthttp.AcquireResponse()
@@ -213,7 +206,7 @@ func (p *Proxy) RequestHandler(ctx *fasthttp.RequestCtx) {
 				}
 			}
 		}
-		error_message := fmt.Sprintf("invalid response: %d", resp.StatusCode())
+		error_message := fmt.Sprintf("invalid response: %d (%s)", resp.StatusCode(), requestURIStr)
 		p.serveMainPage(ctx, resp.StatusCode(), errors.New(error_message))
 		return
 	}
@@ -593,6 +586,7 @@ func (rc *RequestConfig) ProxifyURI(uri string) (string, error) {
 	if rc.Key == nil {
 		return fmt.Sprintf("./?mortyurl=%s", url.QueryEscape(uri)), nil
 	}
+
 	return fmt.Sprintf("./?mortyhash=%s&mortyurl=%s", hash(uri, rc.Key), url.QueryEscape(uri)), nil
 }
 


### PR DESCRIPTION
Query parameters in requested URI were parsed and set again.
Unfortunately a query ```?a&b``` were changed into ```?a=b=``` which can lead to 404 errors.

Fix #14. 