### PR TITLE
[enh] parse and filter Content-Type.

### DIFF
--- a/contenttype/contenttype.go
+++ b/contenttype/contenttype.go
@@ -1,0 +1,98 @@
+package contenttype
+
+import (
+	"mime"
+	"strings"
+)
+
+type ContentType struct {
+	TopLevelType string
+	SubType      string
+	Suffix       string
+	Parameters   map[string]string
+}
+
+func (contenttype *ContentType) String() string {
+	var mimetype string
+	if contenttype.Suffix == "" {
+		if contenttype.SubType == "" {
+			mimetype = contenttype.TopLevelType
+		} else {
+			mimetype = contenttype.TopLevelType + "/" + contenttype.SubType
+		}
+	} else {
+		mimetype = contenttype.TopLevelType + "/" + contenttype.SubType + "+" + contenttype.Suffix
+	}
+	return mime.FormatMediaType(mimetype, contenttype.Parameters)
+}
+
+func (contenttype *ContentType) Equals(other ContentType) bool {
+	if contenttype.TopLevelType != other.TopLevelType ||
+		contenttype.SubType != other.SubType ||
+		contenttype.Suffix != other.Suffix ||
+		len(contenttype.Parameters) != len(other.Parameters) {
+		return false
+	}
+	for k, v := range contenttype.Parameters {
+		if other.Parameters[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (contenttype *ContentType) FilterParameters(parameters map[string]bool) {
+	for k, _ := range contenttype.Parameters {
+		if !parameters[k] {
+			delete(contenttype.Parameters, k)
+		}
+	}
+}
+
+func ParseContentType(contenttype string) (ContentType, error) {
+	mimetype, params, err := mime.ParseMediaType(contenttype)
+	if err != nil {
+		return ContentType{"", "", "", params}, err
+	}
+	splitted_mimetype := strings.SplitN(strings.ToLower(mimetype), "/", 2)
+	if len(splitted_mimetype) <= 1 {
+		return ContentType{splitted_mimetype[0], "", "", params}, nil
+	} else {
+		splitted_subtype := strings.SplitN(splitted_mimetype[1], "+", 2)
+		if len(splitted_subtype) == 1 {
+			return ContentType{splitted_mimetype[0], splitted_subtype[0], "", params}, nil
+		} else {
+			return ContentType{splitted_mimetype[0], splitted_subtype[0], splitted_subtype[1], params}, nil
+		}
+	}
+
+}
+
+type Filter func(contenttype ContentType) bool
+
+func NewFilterContains(partialMimeType string) Filter {
+	return func(contenttype ContentType) bool {
+		return strings.Contains(contenttype.TopLevelType, partialMimeType) ||
+			strings.Contains(contenttype.SubType, partialMimeType) ||
+			strings.Contains(contenttype.Suffix, partialMimeType)
+	}
+}
+
+func NewFilterEquals(TopLevelType, SubType, Suffix string) Filter {
+	return func(contenttype ContentType) bool {
+		return ((TopLevelType != "*" && TopLevelType == contenttype.TopLevelType) || (TopLevelType == "*")) &&
+			((SubType != "*" && SubType == contenttype.SubType) || (SubType == "*")) &&
+			((Suffix != "*" && Suffix == contenttype.Suffix) || (Suffix == "*"))
+	}
+}
+
+func NewFilterOr(contentTypeFilterList []Filter) Filter {
+	return func(contenttype ContentType) bool {
+		for _, contentTypeFilter := range contentTypeFilterList {
+			if contentTypeFilter(contenttype) {
+				return true
+			}
+		}
+		return false
+	}
+}

--- a/contenttype/contenttype_test.go
+++ b/contenttype/contenttype_test.go
@@ -1,0 +1,247 @@
+package contenttype
+
+import (
+	"testing"
+)
+
+type ParseContentTypeTestCase struct {
+	Input          string
+	ExpectedOutput *ContentType /* or nil if an error is expected */
+	ExpectedString *string      /* or nil if equals to Input */
+}
+
+var parseContentTypeTestCases []ParseContentTypeTestCase = []ParseContentTypeTestCase{
+	ParseContentTypeTestCase{
+		"text/html",
+		&ContentType{"text", "html", "", map[string]string{}},
+		nil,
+	},
+	ParseContentTypeTestCase{
+		"text/svg+xml; charset=UTF-8",
+		&ContentType{"text", "svg", "xml", map[string]string{"charset": "UTF-8"}},
+		nil,
+	},
+	ParseContentTypeTestCase{
+		"text/",
+		nil,
+		nil,
+	},
+	ParseContentTypeTestCase{
+		"text; charset=UTF-8",
+		&ContentType{"text", "", "", map[string]string{"charset": "UTF-8"}},
+		nil,
+	},
+	ParseContentTypeTestCase{
+		"text/+xml; charset=UTF-8",
+		&ContentType{"text", "", "xml", map[string]string{"charset": "UTF-8"}},
+		nil,
+	},
+}
+
+type ContentTypeEqualsTestCase struct {
+	A, B   ContentType
+	Equals bool
+}
+
+var Map_Empty map[string]string = map[string]string{}
+var Map_A map[string]string = map[string]string{"a": "value_a"}
+var Map_B map[string]string = map[string]string{"b": "value_b"}
+var Map_AB map[string]string = map[string]string{"a": "value_a", "b": "value_b"}
+
+var ContentType_E ContentType = ContentType{"a", "b", "c", Map_Empty}
+var ContentType_A ContentType = ContentType{"a", "b", "c", Map_A}
+var ContentType_B ContentType = ContentType{"a", "b", "c", Map_B}
+var ContentType_AB ContentType = ContentType{"a", "b", "c", Map_AB}
+
+var contentTypeEqualsTestCases []ContentTypeEqualsTestCase = []ContentTypeEqualsTestCase{
+	// TopLevelType, SubType, Suffix
+	ContentTypeEqualsTestCase{ContentType_E, ContentType{"a", "b", "c", Map_Empty}, true},
+	ContentTypeEqualsTestCase{ContentType_E, ContentType{"o", "b", "c", Map_Empty}, false},
+	ContentTypeEqualsTestCase{ContentType_E, ContentType{"a", "o", "c", Map_Empty}, false},
+	ContentTypeEqualsTestCase{ContentType_E, ContentType{"a", "b", "o", Map_Empty}, false},
+	// Parameters
+	ContentTypeEqualsTestCase{ContentType_A, ContentType_A, true},
+	ContentTypeEqualsTestCase{ContentType_B, ContentType_B, true},
+	ContentTypeEqualsTestCase{ContentType_AB, ContentType_AB, true},
+	ContentTypeEqualsTestCase{ContentType_A, ContentType_E, false},
+	ContentTypeEqualsTestCase{ContentType_A, ContentType_B, false},
+	ContentTypeEqualsTestCase{ContentType_B, ContentType_A, false},
+	ContentTypeEqualsTestCase{ContentType_AB, ContentType_A, false},
+	ContentTypeEqualsTestCase{ContentType_AB, ContentType_E, false},
+	ContentTypeEqualsTestCase{ContentType_A, ContentType_AB, false},
+}
+
+type FilterTestCase struct {
+	Input       Filter
+	TrueValues  []ContentType
+	FalseValues []ContentType
+}
+
+var filterTestCases []FilterTestCase = []FilterTestCase{
+	FilterTestCase{
+		NewFilterContains("xml"),
+		[]ContentType{
+			ContentType{"xml", "", "", Map_Empty},
+			ContentType{"text", "xml", "", Map_Empty},
+			ContentType{"text", "html", "xml", Map_Empty},
+		},
+		[]ContentType{
+			ContentType{"text", "svg", "", map[string]string{"script": "javascript"}},
+			ContentType{"java", "script", "", Map_Empty},
+		},
+	},
+	FilterTestCase{
+		NewFilterEquals("application", "xhtml", "*"),
+		[]ContentType{
+			ContentType{"application", "xhtml", "xml", Map_Empty},
+			ContentType{"application", "xhtml", "", Map_Empty},
+			ContentType{"application", "xhtml", "zip", Map_Empty},
+			ContentType{"application", "xhtml", "zip", Map_AB},
+		},
+		[]ContentType{
+			ContentType{"application", "javascript", "", Map_Empty},
+			ContentType{"text", "xhtml", "", Map_Empty},
+		},
+	},
+	FilterTestCase{
+		NewFilterEquals("application", "*", ""),
+		[]ContentType{
+			ContentType{"application", "xhtml", "", Map_Empty},
+			ContentType{"application", "javascript", "", Map_Empty},
+		},
+		[]ContentType{
+			ContentType{"text", "xhtml", "", Map_Empty},
+			ContentType{"text", "xhtml", "xml", Map_Empty},
+		},
+	},
+	FilterTestCase{
+		NewFilterEquals("*", "javascript", ""),
+		[]ContentType{
+			ContentType{"application", "javascript", "", Map_Empty},
+			ContentType{"text", "javascript", "", Map_Empty},
+		},
+		[]ContentType{
+			ContentType{"text", "html", "", Map_Empty},
+			ContentType{"text", "javascript", "zip", Map_Empty},
+		},
+	},
+	FilterTestCase{
+		NewFilterOr([]Filter{
+			NewFilterEquals("application", "*", ""),
+			NewFilterEquals("*", "javascript", ""),
+		}),
+		[]ContentType{
+			ContentType{"application", "javascript", "", Map_Empty},
+			ContentType{"text", "javascript", "", Map_Empty},
+			ContentType{"application", "xhtml", "", Map_Empty},
+		},
+		[]ContentType{
+			ContentType{"text", "html", "", Map_Empty},
+			ContentType{"application", "xhtml", "xml", Map_Empty},
+		},
+	},
+}
+
+type FilterParametersTestCase struct {
+	Input  map[string]string
+	Filter map[string]bool
+	Output map[string]string
+}
+
+var filterParametersTestCases []FilterParametersTestCase = []FilterParametersTestCase{
+	FilterParametersTestCase{
+		map[string]string{},
+		map[string]bool{"A": true, "B": true},
+		map[string]string{},
+	},
+	FilterParametersTestCase{
+		map[string]string{"A": "value_A", "B": "value_B"},
+		map[string]bool{},
+		map[string]string{},
+	},
+	FilterParametersTestCase{
+		map[string]string{"A": "value_A", "B": "value_B"},
+		map[string]bool{"A": true},
+		map[string]string{"A": "value_A"},
+	},
+	FilterParametersTestCase{
+		map[string]string{"A": "value_A", "B": "value_B"},
+		map[string]bool{"A": true, "B": true},
+		map[string]string{"A": "value_A", "B": "value_B"},
+	},
+}
+
+func TestContentTypeEquals(t *testing.T) {
+	for _, testCase := range contentTypeEqualsTestCases {
+		if !testCase.A.Equals(testCase.B) && testCase.Equals {
+			t.Errorf(`Must be equals "%s"="%s"`, testCase.A, testCase.B)
+		} else if testCase.A.Equals(testCase.B) && !testCase.Equals {
+			t.Errorf(`Mustn't be equals "%s"!="%s"`, testCase.A, testCase.B)
+		}
+	}
+}
+
+func TestParseContentType(t *testing.T) {
+	for _, testCase := range parseContentTypeTestCases {
+		// test ParseContentType
+		contentType, err := ParseContentType(testCase.Input)
+		if testCase.ExpectedOutput == nil {
+			// error expected
+			if err == nil {
+				// but there is no error
+				t.Errorf(`Expecting error for "%s"`, testCase.Input)
+			}
+		} else {
+			// no expected error
+			if err != nil {
+				t.Errorf(`Unexpecting error for "%s" : %s`, testCase.Input, err)
+			} else if !contentType.Equals(*testCase.ExpectedOutput) {
+				// the parsed contentType doesn't matched
+				t.Errorf(`Unexpecting result for "%s", instead got "%s"`, testCase.ExpectedOutput.String(), contentType.String())
+			} else {
+				// ParseContentType is fine, checking String()
+				contentTypeString := contentType.String()
+				expectedString := testCase.Input
+				if testCase.ExpectedString != nil {
+					expectedString = *testCase.ExpectedString
+				}
+				if contentTypeString != expectedString {
+					t.Errorf(`Error with String() output of "%s", got "%s", ContentType{"%s", "%s", "%s", "%s"}`, expectedString, contentTypeString, contentType.TopLevelType, contentType.SubType, contentType.Suffix, contentType.Parameters)
+				}
+			}
+		}
+	}
+}
+
+func TestFilters(t *testing.T) {
+	for _, testCase := range filterTestCases {
+		for _, contentType := range testCase.TrueValues {
+			if !testCase.Input(contentType) {
+				t.Errorf(`Filter "%s" must accept the value "%s"`, testCase.Input, contentType)
+			}
+		}
+		for _, contentType := range testCase.FalseValues {
+			if testCase.Input(contentType) {
+				t.Errorf(`Filter "%s" mustn't accept the value "%s"`, testCase.Input, contentType)
+			}
+		}
+	}
+}
+
+func TestFilterParameters(t *testing.T) {
+	for _, testCase := range filterParametersTestCases {
+		// copy Input since the map will be modified
+		InputCopy := make(map[string]string)
+		for k, v := range testCase.Input {
+			InputCopy[k] = v
+		}
+		// apply filter
+		contentType := ContentType{"", "", "", InputCopy}
+		contentType.FilterParameters(testCase.Filter)
+		// test
+		contentTypeOutput := ContentType{"", "", "", testCase.Output}
+		if !contentTypeOutput.Equals(contentType) {
+			t.Errorf(`FilterParameters error : %s becomes %s with this filter %s`, testCase.Input, contentType.Parameters, testCase.Filter)
+		}
+	}
+}


### PR DESCRIPTION
* svg, mathml, multipart, xml (because of namespaces) are forbidden (see morty.go for the details)
* the charset parameters in Content-Type is only set when it is set by the original server.
* the conversion to UTF-8 is now done for the */xhtml+* Content-Type (it wasn't the case before).
* string type is used because of the mime package API.

**Important note :** There is reference to github.com/dalf/morty/contenttype which should be changed to github.com/dalf/asciimoo/contenttype : may be I miss something, I don't see another way ( ```./contenttype``` doesn't work)