### PR TITLE
Add manual page for the "man" manual program in roff format

### DIFF
--- a/morty.1
+++ b/morty.1
@@ -1,0 +1,57 @@
+.TH MORTY "1" "2018" "morty" "User Commands"
+.SH NAME
+morty \- Privacy aware web content sanitizer proxy as a service
+.SH SYNOPSIS
+.B morty
+.RI [ OPTIONS ]
+.br
+.SH DESCRIPTION
+Morty rewrites web pages to exclude malicious HTML tags and attributes. It
+also replaces external resource references to prevent third party
+information leaks.
+.sp
+The main goal of morty is to provide a result proxy for searx, but it can be
+used as a standalone sanitizer service too.
+.SH OPTIONS
+.HP
+\fB\-ipv6\fR
+.IP
+Allow IPv6 HTTP requests
+.HP
+\fB\-key\fR string
+.IP
+HMAC url validation key (hexadecimal encoded) \- leave blank to disable
+.HP
+\fB\-listen\fR string
+.IP
+Listen address (default "127.0.0.1:3000")
+.HP
+\fB\-timeout\fR uint
+.IP
+Request timeout (default 2)
+.HP
+\fB\-version\fR
+.IP
+Show version
+.SH BUGS
+Bugs or suggestions? Visit the issue tracker at
+https://github.com/asciimoo/morty/issues.
+.SH SEE ALSO
+.BR searx (1)
+.SH LICENSE
+Copyright 2016-2018 Adam Tauber <asciimoo@gmail.com>
+.br
+Copyright 2016 Alexandre Flament <alex@al-f.net>
+.sp
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU Affero General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version.
+.sp
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU Affero General Public License for more
+details.
+.sp
+You should have received a copy of the GNU Affero General Public License along
+with this program. If not, see <http://www.gnu.org/licenses/>.


### PR DESCRIPTION
On unix it is customary to read how a program is used by invoking the `man` command. This pull request provides the content of such a manual page.