### PR TITLE
Update minimum version requirement to Go >= 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: go
 
 go:
-  - 1.6
-  - 1.7
-  - 1.8.3
+  - 1.10.3
 
 script:
   # static checks

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Features:
 
 
 ## Installation and setup
+Requirement: Go version 1.10 or higher.
 
 ```
 $ go get github.com/asciimoo/morty


### PR DESCRIPTION
Fixes #62: Go >= 1.9 is needed to provide math/bits dependency.