### PR TITLE
Add Dockerfile and Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,12 @@ FROM alpine:latest
 
 EXPOSE 3000
 
-WORKDIR /
 RUN apk --no-cache add ca-certificates
-RUN mkdir /etc/morty
 
-COPY --from=builder /go/src/github.com/asciimoo/morty/morty /usr/bin/morty
+RUN adduser -D -h /usr/local/morty -s /bin/sh morty morty
 
-ENTRYPOINT ["/usr/bin/morty"]
+USER morty
+
+COPY --from=builder /go/src/github.com/asciimoo/morty/morty /usr/local/morty/morty
+
+ENTRYPOINT ["/usr/local/morty/morty"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# STEP 1 build executable binary
+FROM golang:alpine as builder
+
+WORKDIR $GOPATH/src/github.com/asciimoo/morty
+
+RUN apk add --no-cache git
+
+COPY . .
+RUN go get -d -v
+RUN go build .
+
+# STEP 2 build the image including only the binary
+FROM alpine:latest
+
+EXPOSE 3000
+
+WORKDIR /
+RUN apk --no-cache add ca-certificates
+RUN mkdir /etc/morty
+
+COPY --from=builder /go/src/github.com/asciimoo/morty/morty /usr/bin/morty
+
+ENTRYPOINT ["/usr/bin/morty"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # STEP 1 build executable binary
-FROM golang:alpine as builder
+FROM golang:1.12-alpine as builder
 
 WORKDIR $GOPATH/src/github.com/asciimoo/morty
 
@@ -7,19 +7,22 @@ RUN apk add --no-cache git
 
 COPY . .
 RUN go get -d -v
+RUN gofmt -l ./
+#RUN go vet -v ./...
+#RUN go test -v ./...
 RUN go build .
 
 # STEP 2 build the image including only the binary
-FROM alpine:latest
+FROM alpine:3.10
 
 EXPOSE 3000
 
-RUN apk --no-cache add ca-certificates
-
-RUN adduser -D -h /usr/local/morty -s /bin/sh morty morty
-
-USER morty
+RUN apk --no-cache add ca-certificates \
+ && rm -f /var/cache/apk/* \
+ && adduser -D -h /usr/local/morty -s /bin/false morty morty
 
 COPY --from=builder /go/src/github.com/asciimoo/morty/morty /usr/local/morty/morty
+
+USER morty
 
 ENTRYPOINT ["/usr/local/morty/morty"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+APP_NAME=morty
+
+build:
+	docker rmi -f $(APP_NAME):latest
+	docker build -t $(APP_NAME) .
+
+run:
+	@echo "\n /!\ DO NOT use in production\n"
+	docker run --rm -t -i --net=host --name="$(APP_NAME)" $(APP_NAME)

--- a/morty.go
+++ b/morty.go
@@ -975,7 +975,7 @@ func main() {
 	}
 	default_key := os.Getenv("MORTY_KEY")
 	listen := flag.String("listen", default_listen_addr, "Listen address")
-	key := flag.String("key", default_key, "HMAC url validation key (hexadecimal encoded) - leave blank to disable validation")
+	key := flag.String("key", default_key, "HMAC url validation key (base64 encoded) - leave blank to disable validation")
 	ipv6 := flag.Bool("ipv6", false, "Allow IPv6 HTTP requests")
 	version := flag.Bool("version", false, "Show version")
 	requestTimeout := flag.Uint("timeout", 2, "Request timeout")
@@ -993,7 +993,12 @@ func main() {
 	p := &Proxy{RequestTimeout: time.Duration(*requestTimeout) * time.Second}
 
 	if *key != "" {
-		p.Key = []byte(*key)
+		var err error
+		p.Key, err = base64.StdEncoding.DecodeString(*key)
+		if (err != nil) {
+		   log.Fatal("Error parsing -key", err.Error())
+		   os.Exit(1)
+		}
 	}
 
 	log.Println("listening on", *listen)


### PR DESCRIPTION
```make build``` to build a docker image ```morty:latest``` (no need to install golang, it uses a muti-stage Dockerfile)

```make run``` to start morty, help to debug.

should help https://github.com/asciimoo/searx/issues/1561

related to https://github.com/asciimoo/filtron/pull/4

----

Note that there are still things to do : 
* run morty with a dedicated user instead of root
* compile different docker images automatically on hub.docker.com for amd64, x64, arm, arm64 architectures.
