### PR TITLE
Var to enable/disable debug logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,6 @@ COPY --from=builder /go/src/github.com/asciimoo/morty/morty /usr/local/morty/mor
 
 USER morty
 
+ENV DEBUG=true
+
 ENTRYPOINT ["/usr/local/morty/morty"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ $ go get github.com/asciimoo/morty
 $ "$GOPATH/bin/morty" --help
 ```
 
+### Environment variables
+
+Morty can be configured using the following environment variables:
+- `MORTY_ADDRESS`: Listen address (default to `127.0.0.1:3000`)
+- `MORTY_KEY`: HMAC url validation key (base64 encoded) to prevent direct URL opening. Leave blank to disable validation. Use `openssl rand -base64 33` to generate.
+- `DEBUG`: Enable/disable proxy and redirection logs (default to `true`). Set to `false` to disable.
+
+### Docker
+
+```
+docker run -e DEBUG=false -e MORTY_ADDRESS=0.0.0.0:3000 -v ./rules.json:/etc/filtron/rules.json:rw dalf/morty
+```
+
+```
+docker run -e DEBUG=false -v ./rules.json:/etc/filtron/rules.json:rw dalf/morty -listen 0.0.0.0:3000
+```
+
 
 ### Test
 

--- a/morty.go
+++ b/morty.go
@@ -36,7 +36,7 @@ const (
 
 const VERSION = "v0.2.0"
 
-var DEBUG = os.Getenv("DEBUG") == "true"
+var DEBUG = os.Getenv("DEBUG") != "false"
 
 var CLIENT *fasthttp.Client = &fasthttp.Client{
 	MaxResponseBodySize: 10 * 1024 * 1024, // 10M

--- a/morty.go
+++ b/morty.go
@@ -36,6 +36,13 @@ const (
 
 const VERSION = "v0.2.0"
 
+var DEBUG = os.Getenv("DEBUG")
+if DEBUG == "true" {
+	DEBUG = true
+} else {
+	DEBUG = false
+}
+
 var CLIENT *fasthttp.Client = &fasthttp.Client{
 	MaxResponseBodySize: 10 * 1024 * 1024, // 10M
 }
@@ -307,7 +314,9 @@ func (p *Proxy) RequestHandler(ctx *fasthttp.RequestCtx) {
 
 	requestURIStr := string(requestURI)
 
-	log.Println("getting", requestURIStr)
+	if DEBUG {
+		log.Println("getting", requestURIStr)
+	}
 
 	req.SetRequestURI(requestURIStr)
 	req.Header.SetUserAgentBytes([]byte("Mozilla/5.0 (Windows NT 10.0; WOW64; rv:50.0) Gecko/20100101 Firefox/50.0"))
@@ -343,7 +352,9 @@ func (p *Proxy) RequestHandler(ctx *fasthttp.RequestCtx) {
 				if err == nil {
 					ctx.SetStatusCode(resp.StatusCode())
 					ctx.Response.Header.Add("Location", url)
-					log.Println("redirect to", string(loc))
+					if DEBUG {
+						log.Println("redirect to", string(loc))
+					}
 					return
 				}
 			}
@@ -512,7 +523,7 @@ func sanitizeCSS(rc *RequestConfig, out io.Writer, css []byte) {
 			out.Write(css[startIndex:urlStart])
 			out.Write([]byte(uri))
 			startIndex = urlEnd
-		} else {
+		} else if DEBUG {
 			log.Println("cannot proxify css uri:", string(css[urlStart:urlEnd]))
 		}
 	}
@@ -533,7 +544,7 @@ func sanitizeHTML(rc *RequestConfig, out io.Writer, htmlDoc []byte) {
 		if token == html.ErrorToken {
 			err := decoder.Err()
 			if err != io.EOF {
-				log.Println("failed to parse HTML:")
+				log.Println("failed to parse HTML")
 			}
 			break
 		}
@@ -775,7 +786,7 @@ func sanitizeAttr(rc *RequestConfig, out io.Writer, attrName, attrValue, escaped
 	case "src", "href", "action":
 		if uri, err := rc.ProxifyURI(attrValue); err == nil {
 			fmt.Fprintf(out, " %s=\"%s\"", attrName, uri)
-		} else {
+		} else if DEBUG {
 			log.Println("cannot proxify uri:", string(attrValue))
 		}
 	case "style":
@@ -925,7 +936,9 @@ func verifyRequestURI(uri, hashMsg, key []byte) bool {
 	h := make([]byte, hex.DecodedLen(len(hashMsg)))
 	_, err := hex.Decode(h, hashMsg)
 	if err != nil {
-		log.Println("hmac error:", err)
+		if DEBUG {
+			log.Println("hmac error:", err)
+		}
 		return false
 	}
 	mac := hmac.New(sha256.New, key)
@@ -951,7 +964,9 @@ func (p *Proxy) serveMainPage(ctx *fasthttp.RequestCtx, statusCode int, err erro
 	ctx.SetStatusCode(statusCode)
 	ctx.Write([]byte(MORTY_HTML_PAGE_START))
 	if err != nil {
-		log.Println("error:", err)
+		if DEBUG {
+			log.Println("error:", err)
+		}
 		ctx.Write([]byte("<h2>Error: "))
 		ctx.Write([]byte(html.EscapeString(err.Error())))
 		ctx.Write([]byte("</h2>"))

--- a/morty.go
+++ b/morty.go
@@ -36,7 +36,7 @@ const (
 
 const VERSION = "v0.2.0"
 
-const DEBUG = os.Getenv("DEBUG") == "true"
+var DEBUG = os.Getenv("DEBUG") == "true"
 
 var CLIENT *fasthttp.Client = &fasthttp.Client{
 	MaxResponseBodySize: 10 * 1024 * 1024, // 10M

--- a/morty.go
+++ b/morty.go
@@ -36,12 +36,7 @@ const (
 
 const VERSION = "v0.2.0"
 
-var DEBUG = os.Getenv("DEBUG")
-if DEBUG == "true" {
-	DEBUG = true
-} else {
-	DEBUG = false
-}
+const DEBUG = os.Getenv("DEBUG") == "true"
 
 var CLIENT *fasthttp.Client = &fasthttp.Client{
 	MaxResponseBodySize: 10 * 1024 * 1024, // 10M


### PR DESCRIPTION
:sparkles: Var to enable/disable debug logs to close #79

Startup and configuration errors are still displayed with DEBUG to false, but any proxied or redirected resources will not appear in the logs.
This will allow to remove the `driver: none` when using docker-compose while still keeping privacy:

https://github.com/searx/searx-docker/blob/master/docker-compose.yaml:
```
  morty:
    container_name: morty
    image: dalf/morty
    hostname: morty
    restart: always
    ports:
      - 127.0.0.1:3000:3000
    networks:
      searx:
        ipv4_address: 10.10.10.5
    command: -listen 10.10.10.5:3000 -timeout 6 -ipv6
    environment:
      - DEBUG=false
      - MORTY_KEY=${MORTY_KEY}
    read_only: true
    cap_drop:
      - ALL
```