### PR TITLE
Support for HTTP proxy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/asciimoo/morty
 go 1.14
 
 require (
-	github.com/valyala/fasthttp v1.14.0
-	golang.org/x/net v0.0.0-20200707034311-ab3426394381
+	github.com/valyala/fasthttp v1.21.0
+	golang.org/x/net v0.0.0-20201016165138-7b1cca2348c0
 	golang.org/x/text v0.3.3
 )

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,14 @@ github.com/andybalholm/brotli v1.0.0 h1:7UCwP93aiSfvWpapti8g88vVVGp2qqtGyePsSuDa
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/klauspost/compress v1.10.4 h1:jFzIFaf586tquEB5EhzQG0HwGNSlgAJpG53G6Ss11wc=
 github.com/klauspost/compress v1.10.4/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.10.7 h1:7rix8v8GpI3ZBb0nSozFRgbtXKv+hOe+qfEpZqybrAg=
+github.com/klauspost/compress v1.10.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.14.0 h1:67bfuW9azCMwW/Jlq/C+VeihNpAuJMWkYPBig1gdi3A=
 github.com/valyala/fasthttp v1.14.0/go.mod h1:ol1PCaL0dX20wC0htZ7sYCsvCYmrouYra0zHzaclZhE=
+github.com/valyala/fasthttp v1.21.0 h1:fJjaQ7cXdaSF9vDBujlHLDGj7AgoMTMIXvICeePzYbU=
+github.com/valyala/fasthttp v1.21.0/go.mod h1:jjraHZVbKOXftJfsOYoAjaeygpj5hr8ermTRJNroD7A=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -14,9 +18,12 @@ golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201016165138-7b1cca2348c0 h1:5kGOVHlq0euqwzgTC9Vu15p6fV1Wi0ArVi8da2urnVg=
+golang.org/x/net v0.0.0-20201016165138-7b1cca2348c0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/morty.go
+++ b/morty.go
@@ -37,7 +37,7 @@ const (
 	STATE_IN_NOSCRIPT int = 2
 )
 
-const VERSION = "v0.2.0"
+const VERSION = "v0.2.1"
 
 const MAX_REDIRECT_COUNT = 5
 
@@ -1056,12 +1056,14 @@ func (p *Proxy) serveMainPage(ctx *fasthttp.RequestCtx, statusCode int, err erro
 func main() {
 	cfg.ListenAddress = *flag.String("listen", cfg.ListenAddress, "Listen address")
 	cfg.Key = *flag.String("key", cfg.Key, "HMAC url validation key (base64 encoded) - leave blank to disable validation")
-	cfg.IPV6 = *flag.Bool("ipv6", cfg.IPV6, "Allow IPv6 HTTP requests")
 	cfg.Debug = *flag.Bool("debug", cfg.Debug, "Debug mode")
 	cfg.RequestTimeout = *flag.Uint("timeout", cfg.RequestTimeout, "Request timeout")
 	cfg.FollowRedirect = *flag.Bool("followredirect", cfg.FollowRedirect, "Follow HTTP GET redirect")
+	proxyenv := flag.Bool("proxyenv", false, "Use a HTTP proxy as set in the environment (HTTP_PROXY, HTTPS_PROXY and NO_PROXY). Overrides -proxy, -socks5, -ipv6.")
+	proxy := flag.String("proxy", "", "Use the specified HTTP proxy (ie: '[user:pass@]hostname:port'). Overrides -socks5, -ipv6.")
+	socks5 := flag.String("socks5", "", "Use a SOCKS5 proxy (ie: 'hostname:port'). Overrides -ipv6.")
+	cfg.IPV6 = *flag.Bool("ipv6", cfg.IPV6, "Use IPv6 and IPv4 to send HTTP requests.")
 	version := flag.Bool("version", false, "Show version")
-	socks5 := flag.String("socks5", "", "SOCKS5 proxy")
 	flag.Parse()
 
 	if *version {
@@ -1069,12 +1071,26 @@ func main() {
 		return
 	}
 
-	if *socks5 != "" {
-		// this disables CLIENT.DialDualStack
-		CLIENT.Dial = fasthttpproxy.FasthttpSocksDialer(*socks5)
+	if *proxyenv && os.Getenv("HTTP_PROXY") == "" && os.Getenv("HTTPS_PROXY") == "" {
+		log.Fatal("Error -proxyenv is used but no environment variables named 'HTTP_PROXY' and/or 'HTTPS_PROXY' could be found.")
+		os.Exit(1)
 	}
-	if cfg.IPV6 {
+
+	if *proxyenv && (os.Getenv("HTTP_PROXY") != "" || os.Getenv("HTTPS_PROXY") != "") {
+		CLIENT.Dial = fasthttpproxy.FasthttpProxyHTTPDialer()
+		log.Println("Using environment defined proxy(ies).")
+	} else if *proxy != "" {
+		CLIENT.Dial = fasthttpproxy.FasthttpHTTPDialer(*proxy)
+		log.Println("Using custom HTTP proxy.")
+	} else if *socks5 != "" {
+		CLIENT.Dial = fasthttpproxy.FasthttpSocksDialer(*socks5)
+		log.Println("Using Socks5 proxy.")
+	} else if cfg.IPV6 {
 		CLIENT.Dial = fasthttp.DialDualStack
+		log.Println("Using dual stack (IPv4/IPv6) direct connections.")
+	} else {
+		CLIENT.Dial = fasthttp.Dial
+		log.Println("Using IPv4 only direct connections.")
 	}
 
 	p := &Proxy{RequestTimeout: time.Duration(cfg.RequestTimeout) * time.Second,

--- a/morty.go
+++ b/morty.go
@@ -1076,7 +1076,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if *proxyenv && (os.Getenv("HTTP_PROXY") != "" || os.Getenv("HTTPS_PROXY") != "") {
+	if *proxyenv {
 		CLIENT.Dial = fasthttpproxy.FasthttpProxyHTTPDialer()
 		log.Println("Using environment defined proxy(ies).")
 	} else if *proxy != "" {


### PR DESCRIPTION
Hi,

I wrote this PR to enhance proxy support. In addition to Socks5, it's now possible to use a regular HTTP proxy specified in the process environment variable or using the command line. I also made sure connectivity options are mutually exclusive.

Since it's a minor change, I bumped the version to 0.2.1.

Let me know if the code looks good.

Thank you.