### PR TITLE
Fix Image Proxy 'TCP Timeout' Error

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,8 +25,8 @@ func init() {
 		Debug:          os.Getenv("DEBUG") != "false",
 		ListenAddress:  default_listen_addr,
 		Key:            default_key,
-		IPV6:           true,
-		RequestTimeout: 5,
-		FollowRedirect: false,
+		IPV6:           false,
+		RequestTimeout: 600,
+		FollowRedirect: true,
 	}
 }

--- a/morty.go
+++ b/morty.go
@@ -44,6 +44,7 @@ const MAX_REDIRECT_COUNT = 5
 var CLIENT *fasthttp.Client = &fasthttp.Client{
 	MaxResponseBodySize: 10 * 1024 * 1024, // 10M
 	ReadBufferSize:      16 * 1024,        // 16K
+	MaxConnsPerHost:     4,		       // This will limit each host to 4 connections
 }
 
 var cfg *config.Config = config.DefaultConfig
@@ -1100,7 +1101,7 @@ func main() {
 		log.Println("Using IPv4 only direct connections.")
 	}
 
-	p := &Proxy{RequestTimeout: time.Duration(cfg.RequestTimeout) * time.Second,
+	p := &Proxy{RequestTimeout: time.Duration(cfg.RequestTimeout) * time.Minute,
 		FollowRedirect: cfg.FollowRedirect}
 
 	if cfg.Key != "" {


### PR DESCRIPTION
This will fix issue #106. The changes are as follows:

Inside of ``config/config.go``:

Disable ``IPV6`` due to it not working correctly with most image-based search engines. 
Change ``RequestTimeout`` to something higher to prevent timeouts. Does not change responsiveness of image searches.
Enable ``FollowRedirect``. There were some rare cases where having it disabled caused issues with loading images.

Inside of ``morty.go``:

Add ``MaxConnsPerHost: 4``. This will limit connections per host to 4. Images still load quickly.
Change ``time.Second`` to ``time.Minute``. This adds far more time for an image to load and causes less timeouts.

This should fix *most* issues with timeouts from image-based search engines. Through my testing so far, I have found that at most one image will timeout from a search even after loading 5+ pages of images. This could be higher in some cases as I haven't tested more than a few days but should generally be small enough to not bother the user. 

Unsure if this is required or not but I have changed the following settings in ``/etc/searx/settings.yml`` as well just to make sure that the hosts configuration is the same. Unsure if this changes anything so please do let me know.

```
outgoing:
    pool_connections : 100 
    pool_maxsize : 4
```

Changes should work without any other configuration.
