### PR TITLE
Added configuration for custom parameters in request URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ $ "$GOPATH/bin/morty" --help
         Debug mode (default true)
   -followredirect
         Follow HTTP GET redirect
+  -hashparam string
+    	  User-defined requesting string HASH parameter name (ie: '/?hash=...' or '/?h=...') (default "mortyhash")
   -ipv6
         Allow IPv6 HTTP requests (default true)
   -key string
@@ -51,6 +53,8 @@ $ "$GOPATH/bin/morty" --help
         Use a SOCKS5 proxy (ie: 'hostname:port'). Overrides -ipv6.
   -timeout uint
         Request timeout (default 5)
+  -urlparam string
+    	  User-defined requesting string URL parameter name (ie: '/?url=...' or '/?u=...') (default "mortyurl")
   -version
         Show version
 ```
@@ -60,6 +64,8 @@ $ "$GOPATH/bin/morty" --help
 Morty can additionally be configured using the following environment variables:
 - `MORTY_ADDRESS`: Listen address (default to `127.0.0.1:3000`)
 - `MORTY_KEY`: HMAC url validation key (base64 encoded) to prevent direct URL opening. Leave blank to disable validation. Use `openssl rand -base64 33` to generate.
+- `MORTY_URL_PARAM`: User-defined requesting string URL parameter name (ie: `/?url=...` or `/?u=...`) (default `mortyurl`)
+- `MORTY_HASH_PARAM`: User-defined requesting string HASH parameter name (ie: `/?hash=...` or `/?h=...`) (default `mortyhash`)
 - `DEBUG`: Enable/disable proxy and redirection logs (default to `true`). Set to `false` to disable.
 
 ### Docker

--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,8 @@ type Config struct {
 	IPV6           bool
 	RequestTimeout uint
 	FollowRedirect bool
+	UrlParameter   string
+	HashParameter  string
 }
 
 var DefaultConfig *Config
@@ -20,6 +22,14 @@ func init() {
 	if default_listen_addr == "" {
 		default_listen_addr = "127.0.0.1:3000"
 	}
+	default_url_parameter := os.Getenv("MORTY_URL_PARAM")
+	if default_url_parameter == "" {
+		default_url_parameter = "mortyurl"
+	}
+	default_hash_parameter := os.Getenv("MORTY_HASH_PARAM")
+	if default_hash_parameter == "" {
+		default_hash_parameter = "mortyhash"
+	}
 	default_key := os.Getenv("MORTY_KEY")
 	DefaultConfig = &Config{
 		Debug:          os.Getenv("DEBUG") != "false",
@@ -28,5 +38,7 @@ func init() {
 		IPV6:           true,
 		RequestTimeout: 5,
 		FollowRedirect: false,
+		UrlParameter:   default_url_parameter,
+		HashParameter:  default_hash_parameter,
 	}
 }


### PR DESCRIPTION
### Changes: 

Added **ENVIRONMENT** parameters: 
- `MORTY_URL_PARAM` 
- `MORTY_HASH_PARAM`

together with the corresponding **console** parameters: 

- `-urlparam` 
- `-hashparam`

Now with this modification each instance can be configured individually for any kind of projects

### Motivations:

- For security reasons, hide a proxy software type and name. Prevent leaking this data by hardcoded params name
- Customize and branding parameters for individuals together with the domain
- Possibility create nice and short URLs for system usage like: `dl.io/?u=https://google.com`
